### PR TITLE
fix locale name from "en-EN" to "en-US"

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ now it says that for `lastname` with probability `0.1` it will be emitted `null`
 By default, it is current locale however it could be changed.
 First there could be set a default locale for current config, second there could be set a locale per field like
 ```yaml
-default_locale: en-EN
+default_locale: en-US
 fields:
   - name: lastname
     nullRate: 0.1
@@ -96,7 +96,7 @@ outputs something like
 Sometimes one field should contain a collection like a person could have several phone numbers.
 Let's emulate this with this config
 ```yaml
-default_locale: en-EN
+default_locale: en-US
 fields:
   - name: lastname
     nullRate: 0.1
@@ -124,10 +124,10 @@ could be
 ```
 
 ## Struct
-Also sometimes field could be complex. For example a person could have an address consisting of `country`, `city` and a `streetAddress`.
+Also, sometimes field could be complex. For example a person could have an address consisting of `country`, `city` and a `streetAddress`.
 Here `struct` type could help
 ```yaml
-default_locale: en-EN
+default_locale: en-US
 fields:
   - name: lastname
     nullRate: 0.1

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-default_locale: en-EN
+default_locale: en-US
 fields:
   - name: lastname
     nullRate: 0.1

--- a/datafaker-gen-core/config.yaml
+++ b/datafaker-gen-core/config.yaml
@@ -1,4 +1,4 @@
-default_locale: en-EN
+default_locale: en-US
 fields:
   - name: lastname
     nullRate: 0.1

--- a/datafaker-gen-core/src/test/resources/schemas/config_test.yaml
+++ b/datafaker-gen-core/src/test/resources/schemas/config_test.yaml
@@ -1,4 +1,4 @@
-default_locale: en-EN
+default_locale: en-US
 fields:
   - name: test
     nullRate: 0.1

--- a/datafaker-gen-examples/datafaker-gen-bigquery/config.yaml
+++ b/datafaker-gen-examples/datafaker-gen-bigquery/config.yaml
@@ -1,4 +1,4 @@
-default_locale: en-EN
+default_locale: en-US
 fields:
   - name: id
     generators: [ Number#randomNumber ]

--- a/datafaker-gen-examples/datafaker-gen-rabbitmq/config.yaml
+++ b/datafaker-gen-examples/datafaker-gen-rabbitmq/config.yaml
@@ -1,4 +1,4 @@
-default_locale: en-EN
+default_locale: en-US
 fields:
   - name: lastname
     generators: [ Name#lastName ]


### PR DESCRIPTION
Locale consists of two parts: "language" and "country".
* "en-EN" is not a correct locale because country "EN" does not exist.
* "en-US" and "en-GB" are correct locales because countries "US" and "GB" do exist.

This should fix the failing tests in https://github.com/datafaker-net/datafaker/pull/1249